### PR TITLE
use generic command line argument as executable

### DIFF
--- a/runDataGeneratorTool.bash
+++ b/runDataGeneratorTool.bash
@@ -2,4 +2,4 @@
 
 source tool_env.bash
 
-$PIN_HOME/pin -t DataGenerator/obj-intel64/DataGenerator.so -- DataGenerator/Benchmarks/parallelSimpleTest
+$PIN_HOME/pin -t DataGenerator/obj-intel64/DataGenerator.so -- $@


### PR DESCRIPTION
This one was actually a lot simpler than I thought it was going to be. New usage for PIN tool is:
```./runDataGeneratorTool.bash <executable>```

Any invalid entries for ```<executable>``` will be caught and handled by PIN so no need for input validation.